### PR TITLE
Wazimap SSL by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ greenlet==0.4.6
 gunicorn==18.0
 newrelic==2.40.0.34
 wazimap==0.2.14
-wazimap-mapit==0.2
+wazimap-mapit==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ gevent==1.0.1
 greenlet==0.4.6
 gunicorn==18.0
 newrelic==2.40.0.34
-wazimap==0.2.11
-wazimap-mapit==0.1
+wazimap==0.2.13
+wazimap-mapit==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ greenlet==0.4.6
 gunicorn==18.0
 newrelic==2.40.0.34
 wazimap==0.2.14
-wazimap-mapit==0.3
+wazimap-mapit==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ gevent==1.0.1
 greenlet==0.4.6
 gunicorn==18.0
 newrelic==2.40.0.34
-wazimap==0.2.13
+wazimap==0.2.14
 wazimap-mapit==0.2

--- a/wazimap_za/settings.py
+++ b/wazimap_za/settings.py
@@ -16,7 +16,6 @@ WAZIMAP['country_code'] = 'ZA'
 WAZIMAP['comparative_levels'] = ['province', 'country']
 # this is provided by mapit
 WAZIMAP['geodata'] = 'wazimap_mapit.geo.GeoData'
-WAZIMAP['mapit'] = {'url': 'https://mapit.code4sa.org'}
 WAZIMAP['geometry_data'] = {}
 
 WAZIMAP['levels'] = {

--- a/wazimap_za/settings.py
+++ b/wazimap_za/settings.py
@@ -11,7 +11,7 @@ DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 # Localise this instance of Wazimap
 WAZIMAP['name'] = 'Wazimap South Africa'
-WAZIMAP['url'] = 'http://wazimap.co.za'
+WAZIMAP['url'] = 'https://wazimap.co.za'
 WAZIMAP['country_code'] = 'ZA'
 WAZIMAP['comparative_levels'] = ['province', 'country']
 # this is provided by mapit

--- a/wazimap_za/settings.py
+++ b/wazimap_za/settings.py
@@ -16,6 +16,7 @@ WAZIMAP['country_code'] = 'ZA'
 WAZIMAP['comparative_levels'] = ['province', 'country']
 # this is provided by mapit
 WAZIMAP['geodata'] = 'wazimap_mapit.geo.GeoData'
+WAZIMAP['mapit'] = {'url': 'https://mapit.code4sa.org'}
 WAZIMAP['geometry_data'] = {}
 
 WAZIMAP['levels'] = {


### PR DESCRIPTION
This finalises using Wazimap over SSL.

From Chrome 50, geolocation no longer works on insecure pages, so we need to move.